### PR TITLE
Github actions to auto update release on push

### DIFF
--- a/.github/workflows/ReleasePublisher.yml
+++ b/.github/workflows/ReleasePublisher.yml
@@ -13,7 +13,7 @@ jobs:
       uses: thedoctor0/zip-release@main
       with:
         type: 'zip'
-        filename: 'AEDDF4.zip'
+        filename: 'AEDF4.zip'
         exclusions: '*.git* /*node_modules/* .editorconfig README.md'
     - name: Upload Release
       uses: "marvinpinto/action-automatic-releases@latest"
@@ -21,5 +21,5 @@ jobs:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         automatic_release_tag: "1.12.2"
         prerelease: false
-        title: "AEDDF4 1.12.2"
-        files: 'AEDDF4.zip'
+        title: "AEDF4 1.12.2"
+        files: 'AEDF4.zip'

--- a/.github/workflows/ReleasePublisher.yml
+++ b/.github/workflows/ReleasePublisher.yml
@@ -19,7 +19,7 @@ jobs:
       uses: "marvinpinto/action-automatic-releases@latest"
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: "latest"
-        prerelease: true
+        automatic_release_tag: "1.12.2"
+        prerelease: false
         title: "AEDDF4 1.12.2"
         files: 'AEDDF4.zip'

--- a/.github/workflows/ReleasePublisher.yml
+++ b/.github/workflows/ReleasePublisher.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         type: 'zip'
         filename: 'AEDDF4.zip'
-        exclusions: '*.git* /*node_modules/* .editorconfig'
+        exclusions: '*.git* /*node_modules/* .editorconfig README.md'
     - name: Upload Release
       uses: "marvinpinto/action-automatic-releases@latest"
       with:

--- a/.github/workflows/ReleasePublisher.yml
+++ b/.github/workflows/ReleasePublisher.yml
@@ -1,0 +1,25 @@
+name: "release"
+on:
+  push:
+    branches:
+      - "main"
+jobs:
+  release:
+    name: "Release"
+    runs-on: "ubuntu-latest"
+    steps:
+    - uses: actions/checkout@master
+    - name: Archive Release
+      uses: thedoctor0/zip-release@main
+      with:
+        type: 'zip'
+        filename: 'AEDDF4.zip'
+        exclusions: '*.git* /*node_modules/* .editorconfig'
+    - name: Upload Release
+      uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        automatic_release_tag: "latest"
+        prerelease: true
+        title: "AEDDF4 1.12.2"
+        files: 'AEDDF4.zip'


### PR DESCRIPTION
** Ao aceitar o pull ele criará uma release tag latest que poderá ser disponibilizada fixamente no Technic.

Basta apenas trocar a versão e já estará disponível para todos usuários, para automatizar o versionamento do Technic você pode baixar a extensão do navegador [Autofill](https://chrome.google.com/webstore/detail/autofill/nlmmgnhgdeffjkdckmikfpnddkbbfkkk) e importar esse script (Modificar o local do modpack)

[Autofill Script.txt](https://github.com/CraftGXNetwork/AEDF4/files/9079762/Autofill.Script.txt)

